### PR TITLE
143 formato separador decimal graficos

### DIFF
--- a/src/components/composed/Charts/BarChart/BarGraphic.js
+++ b/src/components/composed/Charts/BarChart/BarGraphic.js
@@ -113,7 +113,7 @@ function BarChart({data, hideModal, active, size, year, month}) {
 			...options.yAxis,
 			axisLabel: {
 				formatter: thousandFormatter,
-				fontSize: currentWidth < 600 ? 8 : "",
+				fontSize: currentWidth < 600 ? 8 : null,
 			},
 		};
 		curChart.setOption({...options});

--- a/src/components/composed/Charts/BarChart/BarGraphic.js
+++ b/src/components/composed/Charts/BarChart/BarGraphic.js
@@ -9,6 +9,7 @@ import {faExternalLinkAlt, faTimes} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {getMonthLength, startingCutPerMonth, startingCutPerYear} from "utils/generalFilter";
 import {useOptionSelectMonth} from "hooks/useOptionSelectMonth";
+import {thousandFormatter} from "../ChartFormatter";
 
 function BarChart({data, hideModal, active, size, year, month}) {
 	const chartRef = useRef(null); // Creo una referencia y la inicializo vacia.
@@ -111,8 +112,8 @@ function BarChart({data, hideModal, active, size, year, month}) {
 		options.yAxis = {
 			...options.yAxis,
 			axisLabel: {
+				formatter: thousandFormatter,
 				fontSize: currentWidth < 600 ? 8 : "",
-				// rotate: currentWidth < 600 ? 90 : 0,
 			},
 		};
 		curChart.setOption({...options});

--- a/src/components/composed/Charts/BarChart/defaultOptions.js
+++ b/src/components/composed/Charts/BarChart/defaultOptions.js
@@ -1,3 +1,5 @@
+import {thousandFormatter, tooltipFormatter} from "../ChartFormatter";
+
 let config = {
 	rotate: 90,
 	align: "left",
@@ -25,6 +27,7 @@ let labelOption = {
 export const options = {
 	tooltip: {
 		trigger: "axis",
+		formatter: tooltipFormatter,
 		axisPointer: {
 			type: "shadow",
 		},
@@ -68,6 +71,9 @@ export const options = {
 	yAxis: [
 		{
 			type: "value",
+			axisLabel: {
+				formatter: thousandFormatter,
+			},
 		},
 	],
 	series: [

--- a/src/components/composed/Charts/BarChart/defaultOptions.js
+++ b/src/components/composed/Charts/BarChart/defaultOptions.js
@@ -29,6 +29,7 @@ export const options = {
 	tooltip: {
 		trigger: "axis",
 		formatter: tooltipFormatter,
+		extraCssText: "width:150px;",
 		axisPointer: {
 			type: "shadow",
 		},

--- a/src/components/composed/Charts/ChartFormatter.js
+++ b/src/components/composed/Charts/ChartFormatter.js
@@ -1,8 +1,29 @@
+import {allMonths} from "utils/constant";
+
+// Funcion que retorna el nombre del mes dado el valor del yaxis
+const getMonthName = (value) => {
+	let month = "";
+	for (let i = 0; i < Object.entries(allMonths).length; i++) {
+		if (value === allMonths[i].shortName) month = allMonths[i].name;
+	}
+	return month;
+};
+
+//Funcion que retorna el valor para evitar la , en los valores mayores a  999
+export const thousandFormatter = (value) => value;
+
+/*Funcion que crea un nuevo formato de tooltip para ser usado en las graficas
+- Mostramos el nombre del mes entero como titulo
+- Reformateamos el contenido
+- Devolvemos todos los valores y evitamos la , al tener un valor mayor a 999
+*/
 export const tooltipFormatter = (params) => {
+	console.log(params);
 	if (params instanceof Array) {
 		if (params.length) {
 			let message = "";
-			message += `<b>${params[0].axisValueLabel}</b>`;
+			if (params[0].axisValueLabel)
+				message += `<b>${getMonthName(params[0].axisValueLabel)}</b>`;
 			params.forEach((param) => {
 				message += `<br/>${param.marker}${param.seriesName}:<span style="float:right"><b>${
 					param.value
@@ -14,12 +35,10 @@ export const tooltipFormatter = (params) => {
 		}
 	} else {
 		let message = "";
-		message += `${params[0].axisValueLabel}`;
-		message += `<br/>${params.marker}${params.seriesName}: <span style="float:right;"><b>${
+		if (params.axisValueLabel) message += `${getMonthName(params.axisValueLabel)}<br/>`;
+		message += `${params.marker}${params.name}: <span style="float:right;"><b>${
 			params.value
 		}</b>${params.data.unit || ""}</b></span>`;
 		return message;
 	}
 };
-
-export const thousandFormatter = (value) => value;

--- a/src/components/composed/Charts/ChartFormatter.js
+++ b/src/components/composed/Charts/ChartFormatter.js
@@ -18,10 +18,10 @@ export const thousandFormatter = (value) => value;
 - Devolvemos todos los valores y evitamos la , al tener un valor mayor a 999
 */
 export const tooltipFormatter = (params) => {
-	console.log(params);
+	//Si recibimos un array de elementos
+	let message = "";
 	if (params instanceof Array) {
 		if (params.length) {
-			let message = "";
 			if (params[0].axisValueLabel)
 				message += `<b>${getMonthName(params[0].axisValueLabel)}</b>`;
 			params.forEach((param) => {
@@ -33,8 +33,8 @@ export const tooltipFormatter = (params) => {
 		} else {
 			return null;
 		}
+		//Si recibimos solo un elemento
 	} else {
-		let message = "";
 		if (params.axisValueLabel) message += `${getMonthName(params.axisValueLabel)}<br/>`;
 		message += `${params.marker}${params.name}: <span style="float:right;"><b>${
 			params.value

--- a/src/components/composed/Charts/ChartFormatter.js
+++ b/src/components/composed/Charts/ChartFormatter.js
@@ -1,0 +1,25 @@
+export const tooltipFormatter = (params) => {
+	if (params instanceof Array) {
+		if (params.length) {
+			let message = "";
+			message += `<b>${params[0].axisValueLabel}</b>`;
+			params.forEach((param) => {
+				message += `<br/>${param.marker}${param.seriesName}:<span style="float:right"><b>${
+					param.value
+				}${param.data.unit || ""}</b></span>`;
+			});
+			return message;
+		} else {
+			return null;
+		}
+	} else {
+		let message = "";
+		message += `${params[0].axisValueLabel}`;
+		message += `<br/>${params.marker}${params.seriesName}: <span style="float:right;"><b>${
+			params.value
+		}</b>${params.data.unit || ""}</b></span>`;
+		return message;
+	}
+};
+
+export const thousandFormatter = (value) => value;

--- a/src/components/composed/Charts/LineChart/LineGraphic.js
+++ b/src/components/composed/Charts/LineChart/LineGraphic.js
@@ -134,7 +134,7 @@ function LineChart({data, active, hideModal, year, month, size}) {
 		options.yAxis = {
 			...options.yAxis,
 			axisLabel: {
-				fontSize: currentWidth < 600 ? 8 : "",
+				fontSize: currentWidth < 600 ? 8 : null,
 				// rotate: currentWidth < 600 ? 90 : 0,
 			},
 		};

--- a/src/components/composed/Charts/LineChart/defaultOptions.js
+++ b/src/components/composed/Charts/LineChart/defaultOptions.js
@@ -1,3 +1,5 @@
+import {thousandFormatter} from "../ChartFormatter";
+
 let config = {
 	rotate: 90,
 	align: "left",
@@ -32,7 +34,11 @@ export const options = {
 		axisTick: {show: false},
 		data: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
 	},
-	yAxis: {},
+	yAxis: {
+		axisLabel: {
+			formatter: thousandFormatter,
+		},
+	},
 	series: [
 		{
 			name: "Sales",

--- a/src/components/composed/Charts/PieChart/defaultOptions.js
+++ b/src/components/composed/Charts/PieChart/defaultOptions.js
@@ -1,6 +1,10 @@
+import {tooltipFormatter} from "../ChartFormatter";
+
 export const options = {
 	tooltip: {
 		trigger: "item",
+		extraCssText: "width: 150px;",
+		formatter: tooltipFormatter,
 	},
 	legend: {
 		data: ["Pisos", "Garages", "Locales", "Chalets"],
@@ -23,7 +27,6 @@ export const options = {
 			type: "pie",
 			radius: "50%",
 			center: ["50%", "50%"],
-
 			data: [
 				{value: 1048, name: "Pisos"},
 				{value: 735, name: "Garages"},


### PR DESCRIPTION
Creado componente ChartFormatter que crea un nuevo formato de tooltip para ser usado en las graficas
- Mostramos el nombre del mes entero como titulo
- Reformateamos el contenido
- Devolvemos todos los valores y evitamos la , al tener un valor mayor a 999
